### PR TITLE
feat: update dependencies in GitHub Action workflow

### DIFF
--- a/.github/workflows/create-pdf.yml
+++ b/.github/workflows/create-pdf.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3 # this checks out the repo in the ubuntu container
+        uses: actions/checkout@v4 # this checks out the repo in the ubuntu container
       - name: "Create a folder called output"
         run: |
           mkdir output
@@ -20,9 +20,9 @@ jobs:
       # Downloading the binaries directly, because they are newer and work better, than the ones that come with Ubuntu latest.
       - name: "Install pandoc and wkhtmltopdf"
         run: |
-          wget https://github.com/jgm/pandoc/releases/download/3.0.1/pandoc-3.0.1-1-amd64.deb
+          wget https://github.com/jgm/pandoc/releases/download/3.6.4/pandoc-3.6.4-1-amd64.deb
           wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
-          sudo apt install ./pandoc-3.0.1-1-amd64.deb
+          sudo apt install ./pandoc-3.6.4-1-amd64.deb
           sudo apt install ./wkhtmltox_0.12.6.1-2.jammy_amd64.deb
 
       - name: "Convert MD to HTML"


### PR DESCRIPTION
Update Pandoc from 3.0.1 to 3.6.4 to utilize newer features and
bugfixes available in the latest release. This ensures we have the
most recent Markdown to HTML conversion capabilities.

Also upgrade actions/checkout from v3 to v4 to take advantage of
performance improvements and security updates in the GitHub Actions
ecosystem.